### PR TITLE
Test that we get a correctly formatted webarchive file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/fixtures/*.html linguist-generated=true

--- a/tests/fixtures/example.com.html
+++ b/tests/fixtures/example.com.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html><html><head>
+    <title>Example Domain</title>
+
+    <meta charset="utf-8">
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+    body {
+        background-color: #f0f0f2;
+        margin: 0;
+        padding: 0;
+        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        
+    }
+    div {
+        width: 600px;
+        margin: 5em auto;
+        padding: 2em;
+        background-color: #fdfdff;
+        border-radius: 0.5em;
+        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
+    }
+    a:link, a:visited {
+        color: #38488f;
+        text-decoration: none;
+    }
+    @media (max-width: 700px) {
+        div {
+            margin: 0 auto;
+            width: auto;
+        }
+    }
+    </style>    
+</head>
+
+<body>
+<div>
+    <h1>Example Domain</h1>
+    <p>This domain is for use in illustrative examples in documents. You may use this
+    domain in literature without prior coordination or asking for permission.</p>
+    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
+</div>
+
+
+</body></html>

--- a/tests/test_save_safari_webarchive.py
+++ b/tests/test_save_safari_webarchive.py
@@ -2,6 +2,7 @@
 
 import os
 import pathlib
+import plistlib
 
 import pytest
 
@@ -25,6 +26,17 @@ def test_creates_a_single_archive(out_path: pathlib.Path) -> None:
     assert result["stdout"] is not None
     assert result["stderr"] is None
     assert out_path.exists()
+
+    with open(out_path, "rb") as in_file:
+        webarchive = plistlib.load(in_file)
+
+    main_resource = webarchive["WebMainResource"]
+
+    assert main_resource["WebResourceURL"] == "https://example.com/"
+    assert (
+        main_resource["WebResourceData"]
+        == open("tests/fixtures/example.com.html", "rb").read()
+    )
 
 
 def test_does_not_overwrite_existing_archive(out_path: pathlib.Path) -> None:


### PR DESCRIPTION
This checks against an early error where the webarchive file would be created, but it was empty.