### PR TITLE
Add a flag to print the version number

### DIFF
--- a/save_safari_webarchive.swift
+++ b/save_safari_webarchive.swift
@@ -19,6 +19,8 @@
 
 import WebKit
 
+let SCRIPT_VERSION = "1.0"
+
 /// Print an error message and terminate the process if there are
 /// any errors while loading a page.
 class ExitOnFailureDelegate: NSObject, WKNavigationDelegate {
@@ -109,6 +111,12 @@ extension WKWebView {
       RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
     }
   }
+}
+
+if CommandLine.arguments.count == 2 && CommandLine.arguments[1] == "--version" {
+  let filename = (CommandLine.arguments[0] as NSString).lastPathComponent
+  print("\(filename) \(SCRIPT_VERSION)")
+  exit(0)
 }
 
 guard CommandLine.arguments.count == 3 else {

--- a/tests/test_save_safari_webarchive.py
+++ b/tests/test_save_safari_webarchive.py
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import plistlib
+import re
 
 import pytest
 
@@ -129,3 +130,13 @@ def test_it_fails_if_url_is_invalid(out_path: pathlib.Path) -> None:
     }
 
     assert not out_path.exists()
+
+
+def test_prints_the_version() -> None:
+    result = save_safari_webarchive(["--version"])
+
+    assert result["returncode"] == 0
+    assert result["stderr"] is None
+    assert re.match(
+        r"^save_safari_webarchive.swift [0-9]+\.[0-9]+\n$", result["stdout"]
+    )


### PR DESCRIPTION
This adds a new command:

```console
$ save_safari_webarchive.swift --version
save_safari_webarchive.swift 1.0
```

This is one of those things I don't think I'll need, but will be handy later!